### PR TITLE
register .C interface

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rssh
 Type: Package
 Title: Rssh
-Version: 1.0
+Version: 1.0.1
 Date: 2014-11-1
 Author: Bruce Hoff <bruce.hoff@sagebase.org>
 Maintainer: Bruce Hoff <bruce.hoff@sagebase.org>

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,4 @@
 exportPattern("sftp[[:alpha:]]+")
 
 ## package has a dynamic library
-useDynLib(Rssh)
+useDynLib(Rssh, .registration=TRUE)

--- a/R/sftpDeleteFile.R
+++ b/R/sftpDeleteFile.R
@@ -6,13 +6,12 @@
 
 sftpDeleteFile<-function(host, username, password, remotepath) {
   resetState()
-  result<-.C("sftp_rm", 
+  result<-.C(C_sftp_rm,
     as.character(host), 
     as.character(username), 
     as.character(password), 
     as.character(remotepath),  
-    as.integer(0),
-    PACKAGE="Rssh")
+    as.integer(0))
   if (result[[5]]==0) return(TRUE) else return(FALSE)
 }
 

--- a/R/sftpDirectoryExists.R
+++ b/R/sftpDirectoryExists.R
@@ -6,13 +6,12 @@
 
 sftpDirectoryExists<-function(host, username, password, remotepath) {
   resetState()
-  result<-.C("sftp_isdir", 
+  result<-.C(C_sftp_isdir,
     as.character(host), 
     as.character(username), 
     as.character(password), 
     as.character(remotepath),  
-    as.integer(0),
-    PACKAGE="Rssh")
+    as.integer(0))
   if (result[[5]]==1) return(TRUE) else return(FALSE)
 }
 

--- a/R/sftpDownload.R
+++ b/R/sftpDownload.R
@@ -6,14 +6,13 @@
 
 sftpDownload<-function(host, username, password, remotepath, localpath) {
   resetState()
-  result<-.C("sftp_download", 
+  result<-.C(C_sftp_download,
     as.character(host), 
     as.character(username), 
     as.character(password), 
     as.character(remotepath), 
     as.character(localpath), 
-    as.integer(0),
-    PACKAGE="Rssh")
+    as.integer(0))
   if (result[[6]]==0) return(TRUE) else return(FALSE)
 }
 

--- a/R/sftpMakeDirectory.R
+++ b/R/sftpMakeDirectory.R
@@ -6,13 +6,12 @@
 
 sftpMakeDirectory<-function(host, username, password, remotepath) {
   resetState()
-  result<-.C("sftp_mkdir", 
+  result<-.C(C_sftp_mkdir,
     as.character(host), 
     as.character(username), 
     as.character(password), 
     as.character(remotepath),  
-    as.integer(0),
-    PACKAGE="Rssh")
+    as.integer(0))
   if (result[[5]]==0) return(TRUE) else return(FALSE)
 }
 

--- a/R/sftpRemoveDirectory.R
+++ b/R/sftpRemoveDirectory.R
@@ -6,13 +6,12 @@
 
 sftpRemoveDirectory<-function(host, username, password, remotepath) {
   resetState()
-  result<-.C("sftp_rmdir", 
+  result<-.C(C_sftp_rmdir,
     as.character(host), 
     as.character(username), 
     as.character(password), 
     as.character(remotepath),  
-    as.integer(0),
-    PACKAGE="Rssh")
+    as.integer(0))
   if (result[[5]]==0) return(TRUE) else return(FALSE)
 }
 

--- a/R/sftpUpload.R
+++ b/R/sftpUpload.R
@@ -6,14 +6,13 @@
 
 sftpUpload<-function(host, username, password, remotepath, localpath) {
   resetState()
-  result<-.C("sftp_upload", 
+  result<-.C(C_sftp_upload,
     as.character(host), 
     as.character(username), 
     as.character(password), 
     as.character(remotepath), 
     as.character(localpath), 
-    as.integer(0),
-    PACKAGE="Rssh")
+    as.integer(0))
   if (result[[6]]==0) return(TRUE) else return(FALSE)
 }
 

--- a/src/R_init_Rssh.c
+++ b/src/R_init_Rssh.c
@@ -5,20 +5,20 @@
 #include <R_ext/Rdynload.h>
 #include "rssh.h"
 
-static const R_CallMethodDef callMethods[] = {
-	    {"sftp_download", (DL_FUNC) &sftp_download, 6},
-	    {"sftp_upload", (DL_FUNC) &sftp_upload, 6},
-	    {"sftp_mkdir", (DL_FUNC) &sftp_mkdir, 5},
-	    {"sftp_rm", (DL_FUNC) &sftp_rm, 5},
-	    {"sftp_rmdir", (DL_FUNC) &sftp_rmdir, 5},
-	    {"sftp_isdir", (DL_FUNC) &sftp_isdir, 5},
+static const R_CMethodDef cMethods[] = {
+	    {"C_sftp_download", (DL_FUNC) &sftp_download, 6},
+	    {"C_sftp_upload", (DL_FUNC) &sftp_upload, 6},
+	    {"C_sftp_mkdir", (DL_FUNC) &sftp_mkdir, 5},
+	    {"C_sftp_rm", (DL_FUNC) &sftp_rm, 5},
+	    {"C_sftp_rmdir", (DL_FUNC) &sftp_rmdir, 5},
+	    {"C_sftp_isdir", (DL_FUNC) &sftp_isdir, 5},
     {NULL, NULL, 0}
 };
 
 void
 R_init_Rssh(DllInfo *info)
 {
-    R_registerRoutines(info, NULL, callMethods, NULL, NULL);
+    R_registerRoutines(info, cMethods, NULL, NULL, NULL);
 }
 
 void


### PR DESCRIPTION
- C code actually uses .C interface, but R_init_... registered as .Call
- Mangle R-visible names with prefix C_...
- use registration when loading dynamic library, so symbols
  are looked up only once and can be referenced explicitly
